### PR TITLE
Change return types of central_line and limits to return list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ---
 
+## 0.0.9
+
+- Change return type of central_line and limits methods to return a list instead of a scalar value
+
 ## 0.0.8
 
 - Standardize `to_dict` keys

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ unpl = xmr.upper_natural_process_limit()[0]  # 85.7
 lnpl = xmr.lower_natural_process_limit()
 x_cl = xmr.x_central_line()[0]  # 32.5
 
-url = xmr.upper_range_limit()
+url = xmr.upper_range_limit()[0]  # 65.36
 mr_cl = xmr.mr_central_line()[0]  # 20
 
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,19 @@ If LNPL is not needed, remove it with the following steps:
 
 The LNPL line will be removed from the X Chart.
 
+## Advanced Usage
 
+### Calculate Limits from Subset of Counts
+
+The central lines and limits calculations can be restricted to a subset of the count data.
+Use the `subset_start_index` and `subset_end_index` parameters when instantiating the XmR object:
+
+```python
+xmr = XmR(counts, subset_start_index=10, subset_end_index=34)  # 24 points of data starting at index 10
+```
+
+When one or both of these optional arguments are provided, the the X and MR central line calculations will be modified to only use the data from `subset_start_index` up to, but not including, `subset_end_index`.
+When these optional arguments are not provided, `subset_start_index` defaults to 0 and `subset_end_index` defaults to the length of `counts`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ counts = [10, 50, 40, 30]
 
 xmr = XmR(counts)
 moving_ranges = xmr.moving_ranges()
-unpl = xmr.upper_natural_process_limit()
+unpl = xmr.upper_natural_process_limit()[0]  # 85.7
 lnpl = xmr.lower_natural_process_limit()
 x_bar = xmr.x_central_line()[0]  # 32.5
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ xmr = XmR(counts)
 moving_ranges = xmr.moving_ranges()
 unpl = xmr.upper_natural_process_limit()
 lnpl = xmr.lower_natural_process_limit()
-x_bar = xmr.x_central_line()
+x_bar = xmr.x_central_line()[0]  # 32.5
 
 url = xmr.upper_range_limit()
 mr_bar = xmr.mr_central_line()

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ counts = [10, 50, 40, 30]
 xmr = XmR(counts)
 moving_ranges = xmr.moving_ranges()
 unpl = xmr.upper_natural_process_limit()[0]  # 85.7
-lnpl = xmr.lower_natural_process_limit()
+lnpl = xmr.lower_natural_process_limit()[0]  # -20.7
 x_cl = xmr.x_central_line()[0]  # 32.5
 
 url = xmr.upper_range_limit()[0]  # 65.36

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ xmr = XmR(counts)
 moving_ranges = xmr.moving_ranges()
 unpl = xmr.upper_natural_process_limit()[0]  # 85.7
 lnpl = xmr.lower_natural_process_limit()
-x_bar = xmr.x_central_line()[0]  # 32.5
+x_cl = xmr.x_central_line()[0]  # 32.5
 
 url = xmr.upper_range_limit()
-mr_bar = xmr.mr_central_line()
+mr_cl = xmr.mr_central_line()[0]  # 20
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "statprocon"
-version = "0.0.8"
+version = "0.0.9"
 authors = [
   { name="Matt McCormick", email="mattmccor@gmail.com" },
 ]

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -53,7 +53,7 @@ class XmR:
         n = len(self.counts)
         return {
             'values': self.counts,
-            'unpl': [self.upper_natural_process_limit()] * n,
+            'unpl': self.upper_natural_process_limit(),
             'cl': self.x_central_line(),
             'lnpl': [self.lower_natural_process_limit()] * n,
         }
@@ -94,7 +94,7 @@ class XmR:
 
         writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
         for i, x in enumerate(self.counts):
-            row = [x, unpl, x_cl[i], lnpl, moving_ranges[i], url, mr_cl]
+            row = [x, unpl[i], x_cl[i], lnpl, moving_ranges[i], url, mr_cl]
             writer.writerow(row)
 
         return output.getvalue()
@@ -131,9 +131,9 @@ class XmR:
         limit = Decimal('3.268') * self.mr_central_line()
         return self.round(limit)
 
-    def upper_natural_process_limit(self) -> Decimal:
+    def upper_natural_process_limit(self) -> Sequence[Decimal]:
         limit = self.x_central_line()[0] + (Decimal('2.660') * self.mr_central_line())
-        return self.round(limit)
+        return [self.round(limit)] * len(self.counts)
 
     def lower_natural_process_limit(self) -> Decimal:
         """
@@ -163,9 +163,10 @@ class XmR:
             True at index i means that self.counts[i] is above the upper_limit or below the lower_limit
         """
 
-        upper = upper_limit or self.upper_natural_process_limit()
+        upper = upper_limit or self.upper_natural_process_limit()[0]
         lower = lower_limit or self.lower_natural_process_limit()
 
+        # TODO: change arguments to take lists
         return self._points_beyond_limits(self.counts, upper, lower)
 
     def rule_1_mr_indices_beyond_limits(self) -> list[bool]:
@@ -234,7 +235,8 @@ class XmR:
         """
         result = [False] * len(self.counts)
 
-        unpl = self.upper_natural_process_limit()
+        # TODO: convert to check each value
+        unpl = self.upper_natural_process_limit()[0]
         lnpl = self.lower_natural_process_limit()
         upper_25 = ((unpl - lnpl) * Decimal('.75')) + lnpl
         lower_25 = ((unpl - lnpl) * Decimal('.25')) + lnpl

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -50,7 +50,6 @@ class XmR:
         """
         Return the values needed for the X chart as a dictionary
         """
-        n = len(self.counts)
         return {
             'values': self.counts,
             'unpl': self.upper_natural_process_limit(),
@@ -62,10 +61,8 @@ class XmR:
         """
         Return the values needed for the MR chart as a dictionary
         """
-        mr = self.moving_ranges()
-        n = len(mr)
         return {
-            'values': mr,
+            'values': self.moving_ranges(),
             'url': self.upper_range_limit(),
             'cl': self.mr_central_line(),
         }

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -165,11 +165,15 @@ class XmR:
         :return: list[bool] A list of boolean values of length(counts)
             True at index i means that self.counts[i] is above the upper_limit or below the lower_limit
         """
+        n = len(self.counts)
+        upper = self.upper_natural_process_limit()
+        if upper_limit:
+            upper = [upper_limit] * n
 
-        upper = upper_limit or self.upper_natural_process_limit()[0]
-        lower = lower_limit or self.lower_natural_process_limit()[0]
+        lower = self.lower_natural_process_limit()
+        if lower_limit:
+            lower = [lower_limit] * n
 
-        # TODO: change arguments to take lists
         return self._points_beyond_limits(self.counts, upper, lower)
 
     def rule_1_mr_indices_beyond_limits(self) -> list[bool]:
@@ -184,7 +188,7 @@ class XmR:
         :return: list[bool] A list of boolean values of length(self.moving_ranges())
             True at index i means that self.moving_ranges()[i] is above the Upper Range Limit
         """
-        return self._points_beyond_limits(self.moving_ranges(), self.upper_range_limit()[0])
+        return self._points_beyond_limits(self.moving_ranges(), self.upper_range_limit())
 
     def rule_2_runs_about_central_line(self) -> list[bool]:
         """
@@ -260,21 +264,25 @@ class XmR:
 
         return result
 
-    def round(self, value: Decimal):
+    def round(self, value: Decimal) -> Decimal:
         return round(value, self.ROUNDING)
 
     @staticmethod
     def _points_beyond_limits(
             data: TYPE_COUNTS | TYPE_MOVING_RANGES,
-            upper_limit: Decimal,
-            lower_limit: Decimal = Decimal('0')
+            upper_limits: Sequence[Decimal],
+            lower_limits: Optional[Sequence[Decimal]] = None
     ) -> list[bool]:
         result = [False] * len(data)
-        for i, val in enumerate(data):
-            if val is None:
+
+        if lower_limits is None:
+            lower_limits = [Decimal('-Inf')] * len(upper_limits)
+
+        for i, (x, w, y) in enumerate(zip(data, lower_limits, upper_limits)):
+            if x is None:  # first index of Moving Ranges
                 continue
 
-            if not lower_limit <= val <= upper_limit:
+            if not w <= x <= y:
                 result[i] = True
 
         return result

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -55,7 +55,7 @@ class XmR:
             'values': self.counts,
             'unpl': self.upper_natural_process_limit(),
             'cl': self.x_central_line(),
-            'lnpl': [self.lower_natural_process_limit()] * n,
+            'lnpl': self.lower_natural_process_limit(),
         }
 
     def mr_to_dict(self) -> dict:
@@ -94,7 +94,7 @@ class XmR:
 
         writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
         for i, x in enumerate(self.counts):
-            row = [x, unpl[i], x_cl[i], lnpl, moving_ranges[i], url[i], mr_cl[i]]
+            row = [x, unpl[i], x_cl[i], lnpl[i], moving_ranges[i], url[i], mr_cl[i]]
             writer.writerow(row)
 
         return output.getvalue()
@@ -137,13 +137,13 @@ class XmR:
         limit = self.x_central_line()[0] + (Decimal('2.660') * self.mr_central_line()[0])
         return [self.round(limit)] * len(self.counts)
 
-    def lower_natural_process_limit(self) -> Decimal:
+    def lower_natural_process_limit(self) -> Sequence[Decimal]:
         """
         LNPL can be negative.
         It's the caller's responsibility to take max(LNPL, 0) if a negative LNPL does not make sense
         """
         limit = self.x_central_line()[0] - (Decimal('2.660') * self.mr_central_line()[0])
-        return self.round(limit)
+        return [self.round(limit)] * len(self.counts)
 
     def rule_1_x_indices_beyond_limits(
             self,
@@ -166,7 +166,7 @@ class XmR:
         """
 
         upper = upper_limit or self.upper_natural_process_limit()[0]
-        lower = lower_limit or self.lower_natural_process_limit()
+        lower = lower_limit or self.lower_natural_process_limit()[0]
 
         # TODO: change arguments to take lists
         return self._points_beyond_limits(self.counts, upper, lower)
@@ -239,7 +239,7 @@ class XmR:
 
         # TODO: convert to check each value
         unpl = self.upper_natural_process_limit()[0]
-        lnpl = self.lower_natural_process_limit()
+        lnpl = self.lower_natural_process_limit()[0]
         upper_25 = ((unpl - lnpl) * Decimal('.75')) + lnpl
         lower_25 = ((unpl - lnpl) * Decimal('.25')) + lnpl
 

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -54,7 +54,7 @@ class XmR:
         return {
             'values': self.counts,
             'unpl': [self.upper_natural_process_limit()] * n,
-            'cl': [self.x_central_line()] * n,
+            'cl': self.x_central_line(),
             'lnpl': [self.lower_natural_process_limit()] * n,
         }
 
@@ -86,15 +86,15 @@ class XmR:
         writer = csv.writer(output)
 
         unpl = self.upper_natural_process_limit()
-        x_bar = self.x_central_line()
+        x_cl = self.x_central_line()
         lnpl = self.lower_natural_process_limit()
         moving_ranges = self.moving_ranges()
         url = self.upper_range_limit()
-        mr_bar = self.mr_central_line()
+        mr_cl = self.mr_central_line()
 
         writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
         for i, x in enumerate(self.counts):
-            row = [x, unpl, x_bar, lnpl, moving_ranges[i], url, mr_bar]
+            row = [x, unpl, x_cl[i], lnpl, moving_ranges[i], url, mr_cl]
             writer.writerow(row)
 
         return output.getvalue()
@@ -117,9 +117,9 @@ class XmR:
         self._mr = result
         return self._mr
 
-    def x_central_line(self) -> Decimal:
+    def x_central_line(self) -> Sequence[Decimal]:
         avg = self.mean(self.counts[self.i:self.j])
-        return self.round(avg)
+        return [self.round(avg)] * len(self.counts)
 
     def mr_central_line(self) -> Decimal:
         assert self.moving_ranges()[0] is None
@@ -132,7 +132,7 @@ class XmR:
         return self.round(limit)
 
     def upper_natural_process_limit(self) -> Decimal:
-        limit = self.x_central_line() + (Decimal('2.660') * self.mr_central_line())
+        limit = self.x_central_line()[0] + (Decimal('2.660') * self.mr_central_line())
         return self.round(limit)
 
     def lower_natural_process_limit(self) -> Decimal:
@@ -140,7 +140,7 @@ class XmR:
         LNPL can be negative.
         It's the caller's responsibility to take max(LNPL, 0) if a negative LNPL does not make sense
         """
-        limit = self.x_central_line() - (Decimal('2.660') * self.mr_central_line())
+        limit = self.x_central_line()[0] - (Decimal('2.660') * self.mr_central_line())
         return self.round(limit)
 
     def rule_1_x_indices_beyond_limits(

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -83,7 +83,7 @@ class XmR:
         writer = csv.writer(output)
 
         writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
-        for x, unpl, x_cl, lnpl, mr, url, mr_cl in zip(
+        writer.writerows(zip(
             self.counts,
             self.upper_natural_process_limit(),
             self.x_central_line(),
@@ -91,10 +91,7 @@ class XmR:
             self.moving_ranges(),
             self.upper_range_limit(),
             self.mr_central_line()
-        ):
-            row = [x, unpl, x_cl, lnpl, mr, url, mr_cl]
-            writer.writerow(row)
-
+        ))
         return output.getvalue()
 
     def moving_ranges(self) -> TYPE_MOVING_RANGES:

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -238,17 +238,14 @@ class XmR:
         """
         result = [False] * len(self.counts)
 
-        # TODO: convert to check each value
-        unpl = self.upper_natural_process_limit()[0]
-        lnpl = self.lower_natural_process_limit()[0]
-        upper_25 = ((unpl - lnpl) * Decimal('.75')) + lnpl
-        lower_25 = ((unpl - lnpl) * Decimal('.25')) + lnpl
-
         # positive value is point near upper limit
         # negative value is point near lower limit
         near_limits = [0] * len(self.counts)
 
-        for i, x in enumerate(self.counts):
+        values = zip(self.counts, self.upper_natural_process_limit(), self.lower_natural_process_limit())
+        for i, (x, unpl, lnpl) in enumerate(values):
+            upper_25 = ((unpl - lnpl) * Decimal('.75')) + lnpl
+            lower_25 = ((unpl - lnpl) * Decimal('.25')) + lnpl
             if x < lower_25:
                 near_limits[i] = -1
 

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -66,7 +66,7 @@ class XmR:
         n = len(mr)
         return {
             'values': mr,
-            'url': [self.upper_range_limit()] * n,
+            'url': self.upper_range_limit(),
             'cl': self.mr_central_line(),
         }
 
@@ -94,7 +94,7 @@ class XmR:
 
         writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
         for i, x in enumerate(self.counts):
-            row = [x, unpl[i], x_cl[i], lnpl, moving_ranges[i], url, mr_cl[i]]
+            row = [x, unpl[i], x_cl[i], lnpl, moving_ranges[i], url[i], mr_cl[i]]
             writer.writerow(row)
 
         return output.getvalue()
@@ -128,9 +128,10 @@ class XmR:
         avg = self.mean(valid_values)
         return [self.round(avg)] * len(mr)
 
-    def upper_range_limit(self) -> Decimal:
-        limit = Decimal('3.268') * self.mr_central_line()[0]
-        return self.round(limit)
+    def upper_range_limit(self) -> Sequence[Decimal]:
+        mr_cl = self.mr_central_line()
+        limit = Decimal('3.268') * mr_cl[0]
+        return [self.round(limit)] * len(mr_cl)
 
     def upper_natural_process_limit(self) -> Sequence[Decimal]:
         limit = self.x_central_line()[0] + (Decimal('2.660') * self.mr_central_line()[0])
@@ -182,7 +183,7 @@ class XmR:
         :return: list[bool] A list of boolean values of length(self.moving_ranges())
             True at index i means that self.moving_ranges()[i] is above the Upper Range Limit
         """
-        return self._points_beyond_limits(self.moving_ranges(), self.upper_range_limit())
+        return self._points_beyond_limits(self.moving_ranges(), self.upper_range_limit()[0])
 
     def rule_2_runs_about_central_line(self) -> list[bool]:
         """

--- a/statprocon/charts/xmr.py
+++ b/statprocon/charts/xmr.py
@@ -85,16 +85,17 @@ class XmR:
         output = io.StringIO()
         writer = csv.writer(output)
 
-        unpl = self.upper_natural_process_limit()
-        x_cl = self.x_central_line()
-        lnpl = self.lower_natural_process_limit()
-        moving_ranges = self.moving_ranges()
-        url = self.upper_range_limit()
-        mr_cl = self.mr_central_line()
-
         writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
-        for i, x in enumerate(self.counts):
-            row = [x, unpl[i], x_cl[i], lnpl[i], moving_ranges[i], url[i], mr_cl[i]]
+        for x, unpl, x_cl, lnpl, mr, url, mr_cl in zip(
+            self.counts,
+            self.upper_natural_process_limit(),
+            self.x_central_line(),
+            self.lower_natural_process_limit(),
+            self.moving_ranges(),
+            self.upper_range_limit(),
+            self.mr_central_line()
+        ):
+            row = [x, unpl, x_cl, lnpl, mr, url, mr_cl]
             writer.writerow(row)
 
         return output.getvalue()

--- a/tests/test_xmr.py
+++ b/tests/test_xmr.py
@@ -40,7 +40,7 @@ mr_cl    : [1.000, 1.000, 1.000]
     def test_average_contains_one_more_exponent_as_input(self):
         counts = [3, 3, 4]
         xmr = XmR(counts)
-        self.assertEqual(xmr.x_central_line(), Decimal('3.333'))
+        self._assert_line_equals(xmr, 'x_central_line', Decimal('3.333'))
 
     def test_moving_range_ints(self):
         counts = [1, 10, 100, 50]
@@ -91,7 +91,7 @@ mr_cl    : [1.000, 1.000, 1.000]
 
         # Adjust manually so that all subset values should be 1
         xmr.i = 4
-        self.assertEqual(xmr.x_central_line(), 1)
+        self._assert_line_equals(xmr, 'x_central_line', 1)
         self.assertEqual(xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit())
 
     def test_rule_1_points_beyond_upper_limits(self):
@@ -240,3 +240,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 1))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit(), 1))
         self.assertEqual(url, round(xmr.upper_range_limit(), 1))
+
+    def _assert_line_equals(self, xmr, func, value):
+        actual = getattr(xmr, func)()
+        self.assertListEqual(actual, [value] * len(xmr.counts))

--- a/tests/test_xmr.py
+++ b/tests/test_xmr.py
@@ -70,8 +70,7 @@ mr_cl    : [1.000, 1.000, 1.000]
     def test_upper_natural_process_limit(self):
         counts = [1, 10, 100, 50]
         xmr = XmR(counts)
-        limit = xmr.upper_natural_process_limit()
-        self.assertEqual(limit, Decimal('172.364'))
+        self._assert_line_equals(xmr, 'upper_natural_process_limit', Decimal('172.364'))
 
     def test_lower_natural_process_limit(self):
         counts = [1, 10, 100, 50]
@@ -86,13 +85,13 @@ mr_cl    : [1.000, 1.000, 1.000]
         counts[3] = 50
 
         xmr = XmR(counts, subset_end_index=24)
-        self.assertEqual(xmr.upper_natural_process_limit(), Decimal('30.442'))
+        self._assert_line_equals(xmr, 'upper_natural_process_limit', Decimal('30.442'))
         self.assertEqual(xmr.upper_range_limit(), Decimal('28.134'))
 
         # Adjust manually so that all subset values should be 1
         xmr.i = 4
         self._assert_line_equals(xmr, 'x_central_line', 1)
-        self.assertEqual(xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit())
+        self.assertEqual(xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit()[0])
 
     def test_rule_1_points_beyond_upper_limits(self):
         """
@@ -213,7 +212,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertEqual(x_avg, xmr.mean(counts))
         self.assertEqual(mr_avg, round(xmr.mr_central_line(), 2))
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 2))
-        self.assertEqual(unpl, round(xmr.upper_natural_process_limit(), 2))
+        self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 2))
         self.assertEqual(url, round(xmr.upper_range_limit(), 2))
 
     def test_peak_flow_rates(self):
@@ -238,7 +237,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertEqual(x_avg, round(xmr.mean(x_values), 1))
         self.assertEqual(mr_avg, round(xmr.mr_central_line(), 1))
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 1))
-        self.assertEqual(unpl, round(xmr.upper_natural_process_limit(), 1))
+        self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 1))
         self.assertEqual(url, round(xmr.upper_range_limit(), 1))
 
     def _assert_line_equals(self, xmr, func, value):

--- a/tests/test_xmr.py
+++ b/tests/test_xmr.py
@@ -64,8 +64,7 @@ mr_cl    : [1.000, 1.000, 1.000]
     def test_upper_range_limit(self):
         counts = [1,51, 100, 50]
         xmr = XmR(counts)
-        url = xmr.upper_range_limit()
-        self.assertEqual(url, Decimal('162.312'))
+        self._assert_line_equals(xmr, 'upper_range_limit', Decimal('162.312'))
 
     def test_upper_natural_process_limit(self):
         counts = [1, 10, 100, 50]
@@ -86,7 +85,7 @@ mr_cl    : [1.000, 1.000, 1.000]
 
         xmr = XmR(counts, subset_end_index=24)
         self._assert_line_equals(xmr, 'upper_natural_process_limit', Decimal('30.442'))
-        self.assertEqual(xmr.upper_range_limit(), Decimal('28.134'))
+        self._assert_line_equals(xmr, 'upper_range_limit', Decimal('28.134'))
 
         # Adjust manually so that all subset values should be 1
         xmr.i = 4
@@ -213,7 +212,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertEqual(mr_avg, round(xmr.mr_central_line()[0], 2))
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 2))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 2))
-        self.assertEqual(url, round(xmr.upper_range_limit(), 2))
+        self.assertEqual(url, round(xmr.upper_range_limit()[0], 2))
 
     def test_peak_flow_rates(self):
         """
@@ -238,7 +237,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertEqual(mr_avg, round(xmr.mr_central_line()[0], 1))
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 1))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 1))
-        self.assertEqual(url, round(xmr.upper_range_limit(), 1))
+        self.assertEqual(url, round(xmr.upper_range_limit()[0], 1))
 
     def _assert_line_equals(self, xmr, func, value):
         actual = getattr(xmr, func)()

--- a/tests/test_xmr.py
+++ b/tests/test_xmr.py
@@ -74,8 +74,7 @@ mr_cl    : [1.000, 1.000, 1.000]
     def test_lower_natural_process_limit(self):
         counts = [1, 10, 100, 50]
         xmr = XmR(counts)
-        limit = xmr.lower_natural_process_limit()
-        self.assertEqual(limit, Decimal('-91.864'))
+        self._assert_line_equals(xmr, 'lower_natural_process_limit', Decimal('-91.864'))
 
     def test_limits_with_subsets(self):
         counts = [1] * 25
@@ -90,7 +89,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         # Adjust manually so that all subset values should be 1
         xmr.i = 4
         self._assert_line_equals(xmr, 'x_central_line', 1)
-        self.assertEqual(xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit()[0])
+        self.assertEqual(xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit())
 
     def test_rule_1_points_beyond_upper_limits(self):
         """
@@ -210,7 +209,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertListEqual(xmr.moving_ranges(), moving_ranges)
         self.assertEqual(x_avg, xmr.mean(counts))
         self.assertEqual(mr_avg, round(xmr.mr_central_line()[0], 2))
-        self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 2))
+        self.assertEqual(lnpl, round(xmr.lower_natural_process_limit()[0], 2))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 2))
         self.assertEqual(url, round(xmr.upper_range_limit()[0], 2))
 
@@ -235,7 +234,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertListEqual(xmr.moving_ranges(), mr_values)
         self.assertEqual(x_avg, round(xmr.mean(x_values), 1))
         self.assertEqual(mr_avg, round(xmr.mr_central_line()[0], 1))
-        self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 1))
+        self.assertEqual(lnpl, round(xmr.lower_natural_process_limit()[0], 1))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 1))
         self.assertEqual(url, round(xmr.upper_range_limit()[0], 1))
 

--- a/tests/test_xmr.py
+++ b/tests/test_xmr.py
@@ -210,7 +210,7 @@ mr_cl    : [1.000, 1.000, 1.000]
 
         self.assertListEqual(xmr.moving_ranges(), moving_ranges)
         self.assertEqual(x_avg, xmr.mean(counts))
-        self.assertEqual(mr_avg, round(xmr.mr_central_line(), 2))
+        self.assertEqual(mr_avg, round(xmr.mr_central_line()[0], 2))
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 2))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 2))
         self.assertEqual(url, round(xmr.upper_range_limit(), 2))
@@ -235,7 +235,7 @@ mr_cl    : [1.000, 1.000, 1.000]
 
         self.assertListEqual(xmr.moving_ranges(), mr_values)
         self.assertEqual(x_avg, round(xmr.mean(x_values), 1))
-        self.assertEqual(mr_avg, round(xmr.mr_central_line(), 1))
+        self.assertEqual(mr_avg, round(xmr.mr_central_line()[0], 1))
         self.assertEqual(lnpl, round(xmr.lower_natural_process_limit(), 1))
         self.assertEqual(unpl, round(xmr.upper_natural_process_limit()[0], 1))
         self.assertEqual(url, round(xmr.upper_range_limit(), 1))


### PR DESCRIPTION
This standardizes the return value and will make things easier when introducing trended limits.  Trended limits will have sloping lines that will not be constant.