### PR TITLE
Add GitHub Actions CI (uv test matrix + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run python -m unittest discover
+
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run mypy
+        run: uv run mypy statprocon tests
+
+  build:
+    name: Build distribution
+    needs: [test, typecheck]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Build
+        run: uv build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/


### PR DESCRIPTION
PR 2 of the #12 split. Adds CI that replaces the multi-version coverage `tox` gave us locally — now that the uv migration (#13) is merged.

> **Merge after #15** (drop Python 3.9). This PR's matrix targets 3.10–3.14; #15 raises `requires-python` to `>=3.10`. Merging #15 first keeps the floor and the matrix consistent. This branch touches **only** `.github/workflows/ci.yml`.

## What it does

Three jobs in `.github/workflows/ci.yml`, triggered on pushes to `main` and on all PRs:

- **`test`** — matrix over **Python 3.10–3.14**. Each entry runs `uv sync --all-extras` then `uv run python -m unittest discover`. `fail-fast: false` so one version failing still reports the rest.
- **`typecheck`** — runs `uv run mypy statprocon tests` once, on 3.13. mypy resolves typing-module availability from the interpreter it runs under, so a single job matches the previous `tox` type env and avoids redundant runs.
- **`build`** — runs after `test` and `typecheck` pass. `uv build` produces the **single** pure-Python wheel + sdist and uploads them as one `dist` artifact.

## Deltas from the CI in #12

- **Build once, not per-version.** #12 uploaded five identical `py3-none-any` wheels; this package is pure-Python, so one build job suffices.
- **`push` limited to `main`.** #12 used `on: [push, pull_request]`, which double-runs on every PR branch.
- **`fail-fast: false`** to see all version results in one run.
- Dropped `--dev` from `uv sync` (uv installs the dev group by default).

## Verification

Every command was run locally on the branch; the full matrix (3.10–3.14) + typecheck + build pass. CI also runs against this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)