### PR TITLE
Remove packaging and typing_extensions runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 keywords = ["Statistical Process Control", "SPC", "Quality Control Chart", "QCC", "Process Behaviour Chart", "Process Behavior Chart", "XmR", "Shewhart", "Wheeler"]
-dependencies = [
-    "packaging",
-    "typing_extensions",
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/mattmccormick/statprocon"

--- a/statprocon/charts/xmr/types.py
+++ b/statprocon/charts/xmr/types.py
@@ -1,14 +1,13 @@
 from decimal import Decimal
 
-from typing import Union, Sequence, TypeAlias
+from typing import Sequence, TypeAlias
 
-# TODO: can replace Union with | when only supporting >= 3.10
-TYPE_COUNT_VALUE: TypeAlias = Union[Decimal, int]
-TYPE_MOVING_RANGE_VALUE: TypeAlias = Union[Decimal, int, None]
+TYPE_COUNT_VALUE: TypeAlias = Decimal | int
+TYPE_MOVING_RANGE_VALUE: TypeAlias = Decimal | int | None
 
-TYPE_COUNTS_INPUT: TypeAlias = Sequence[Union[TYPE_COUNT_VALUE, float]]
+TYPE_COUNTS_INPUT: TypeAlias = Sequence[TYPE_COUNT_VALUE | float]
 TYPE_COUNTS: TypeAlias = Sequence[TYPE_COUNT_VALUE]
 TYPE_MOVING_RANGES: TypeAlias = Sequence[TYPE_MOVING_RANGE_VALUE]
 
-TYPE_NUMERIC = Union[Decimal, float, int]
-TYPE_NUMERIC_INPUTS = Sequence[Union[TYPE_NUMERIC, None]]
+TYPE_NUMERIC = Decimal | float | int
+TYPE_NUMERIC_INPUTS = Sequence[TYPE_NUMERIC | None]

--- a/statprocon/charts/xmr/types.py
+++ b/statprocon/charts/xmr/types.py
@@ -1,13 +1,6 @@
 from decimal import Decimal
 
-from packaging.markers import Marker
-from typing import Union, Sequence
-
-py310 = Marker('python_version >= "3.10"')
-if py310.evaluate():
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+from typing import Union, Sequence, TypeAlias
 
 # TODO: can replace Union with | when only supporting >= 3.10
 TYPE_COUNT_VALUE: TypeAlias = Union[Decimal, int]

--- a/uv.lock
+++ b/uv.lock
@@ -200,15 +200,6 @@ wheels = [
 ]
 
 [[package]]
-name = "packaging"
-version = "26.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -221,10 +212,6 @@ wheels = [
 name = "statprocon"
 version = "1.0.2"
 source = { editable = "." }
-dependencies = [
-    { name = "packaging" },
-    { name = "typing-extensions" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -233,10 +220,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "packaging" },
-    { name = "typing-extensions" },
-]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
PR 3 of the #12 split. Now that the floor is Python 3.10 (#15), the library's two runtime dependencies are no longer needed.

## Why they existed
Both `packaging` and `typing_extensions` served a single purpose in `types.py`: selecting where `TypeAlias` comes from.

```python
from packaging.markers import Marker
py310 = Marker('python_version >= "3.10"')
if py310.evaluate():
    from typing import TypeAlias
else:
    from typing_extensions import TypeAlias   # Python < 3.10
```

`typing.TypeAlias` was added in 3.10. With 3.9 dropped, every supported version has it, so the runtime guard (`packaging`) and the fallback (`typing_extensions`) are both dead weight.

## Changes
- `types.py`: collapse the guard to `from typing import Sequence, TypeAlias`, and switch the aliases from `typing.Union[...]` to PEP 604 `|` unions (resolving the stale `# TODO: can replace Union with |` now that 3.10 is the floor).
- `pyproject.toml`: `dependencies = []`.
- `uv.lock`: relocked — `packaging` removed entirely; `typing_extensions` now appears **only** as a transitive dep of `mypy` (dev group), not as a runtime dep of statprocon.

**Result: statprocon has zero runtime dependencies.**

## Verification
```
uv run --python 3.10 --isolated python -m unittest discover   # 33 tests, OK (| aliases evaluate at runtime on the floor)
uv run --python 3.14 --isolated python -m unittest discover   # 33 tests, OK
uv run mypy statprocon tests                                  # Success: no issues found in 12 source files
```
The full CI matrix (3.10–3.14) + typecheck + build runs on this PR.

## Not included
- The optional `[plot]` extra (matplotlib/pandas convenience installer) — deferred to a follow-up PR.
- ruff formatting — last PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)