### PR TITLE
Adopt ruff formatter (quotes preserved, data grids protected)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,24 @@ jobs:
       - name: Run mypy
         run: uv run mypy statprocon tests
 
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Check formatting
+        run: uv run ruff format --check
+
   build:
     name: Build distribution
-    needs: [test, typecheck]
+    needs: [test, typecheck, format]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ plot = [
 dev = [
     "mypy>=1.14.1",
     "mypy-extensions>=1.0.0",
+    "ruff>=0.15.0",
 ]
 
 [tool.mypy]
@@ -42,3 +43,12 @@ dev = [
 [[tool.mypy.overrides]]
 module = ["pandas.*", "matplotlib.*"]
 ignore_missing_imports = true
+
+[tool.ruff]
+line-length = 88
+# Mirror requires-python so future lint rules stay safe for all supported versions.
+target-version = "py310"
+
+[tool.ruff.format]
+# Leave existing quote styles untouched.
+quote-style = "preserve"

--- a/statprocon/charts/xmr/base.py
+++ b/statprocon/charts/xmr/base.py
@@ -60,13 +60,13 @@ def _import_pandas() -> Any:
 
 class Base:
     def __init__(
-            self,
-            counts: TYPE_COUNTS_INPUT,
-            x_central_line_uses: str = AVERAGE,
-            moving_range_uses: str = AVERAGE,
-            subset_start_index: int = 0,
-            subset_end_index: Optional[int] = None,
-            limit_floor: TYPE_NUMERIC = Decimal('-Infinity'),
+        self,
+        counts: TYPE_COUNTS_INPUT,
+        x_central_line_uses: str = AVERAGE,
+        moving_range_uses: str = AVERAGE,
+        subset_start_index: int = 0,
+        subset_end_index: Optional[int] = None,
+        limit_floor: TYPE_NUMERIC = Decimal('-Infinity'),
     ):
         """
 
@@ -117,10 +117,10 @@ class Base:
         return result
 
     def x_to_dict(
-            self,
-            include_halfway_lines: bool = False,
-            moving_average_points: Optional[int] = None,
-            include_exponential_moving_average: bool = False,
+        self,
+        include_halfway_lines: bool = False,
+        moving_average_points: Optional[int] = None,
+        include_exponential_moving_average: bool = False,
     ) -> dict:
         """
         Return the values needed for the X chart as a dictionary
@@ -220,10 +220,10 @@ class Base:
         }
 
     def to_dict(
-            self,
-            include_halfway_lines: bool = False,
-            moving_average_points: Optional[int] = None,
-            include_exponential_moving_average: bool = False,
+        self,
+        include_halfway_lines: bool = False,
+        moving_average_points: Optional[int] = None,
+        include_exponential_moving_average: bool = False,
     ) -> dict:
         # Naming comes from pg. 163
         #   So Which Way Should You Compute Limits? from Making Sense of Data
@@ -254,16 +254,20 @@ class Base:
         output = io.StringIO()
         writer = csv.writer(output)
 
-        writer.writerow(['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl'])
-        writer.writerows(zip(
-            self.counts,
-            self.upper_natural_process_limit(),
-            self.x_central_line(),
-            self.lower_natural_process_limit(),
-            self.moving_ranges(),
-            self.upper_range_limit(),
-            self.mr_central_line()
-        ))
+        writer.writerow(
+            ['x_values', 'x_unpl', 'x_cl', 'x_lnpl', 'mr_values', 'mr_url', 'mr_cl']
+        )
+        writer.writerows(
+            zip(
+                self.counts,
+                self.upper_natural_process_limit(),
+                self.x_central_line(),
+                self.lower_natural_process_limit(),
+                self.moving_ranges(),
+                self.upper_range_limit(),
+                self.mr_central_line(),
+            )
+        )
         return output.getvalue()
 
     def moving_ranges(self) -> TYPE_MOVING_RANGES:
@@ -281,7 +285,7 @@ class Base:
         return result
 
     def x_central_line(self) -> Sequence[Decimal]:
-        valid_values = self.counts[self.i:self.j]
+        valid_values = self.counts[self.i : self.j]
         if self._x_central_line_uses == AVERAGE:
             value = self._mean(valid_values)
         elif self._x_central_line_uses == MEDIAN:
@@ -294,13 +298,15 @@ class Base:
 
         result: List[Union[None, Decimal]] = [None] * (n - 1)
         nd = Decimal(n)
-        for i in range(n-1, len(self.counts)):
-            ma = sum(self.counts[i-n+1:i+1]) / nd
+        for i in range(n - 1, len(self.counts)):
+            ma = sum(self.counts[i - n + 1 : i + 1]) / nd
             result.append(ma)
 
         return result
 
-    def x_exponential_moving_average(self, smoothing_factor: float = 0.9) -> List[Decimal]:
+    def x_exponential_moving_average(
+        self, smoothing_factor: float = 0.9
+    ) -> List[Decimal]:
         """
         Returns the Exponential Moving Average for the X data
         :param smoothing_factor The smoothing factor to apply to the function.
@@ -313,14 +319,14 @@ class Base:
         smoothing_pct = Decimal('1') - Decimal(str(smoothing_factor))
         for i in range(1, len(result)):
             curr = result[i]
-            prev = result[i-1]
+            prev = result[i - 1]
             result[i] = round(prev + smoothing_pct * (curr - prev), ROUNDING)
         return result
 
     def mr_central_line(self) -> Sequence[Decimal]:
         mr = self.moving_ranges()
         assert mr[0] is None
-        valid_values = cast(TYPE_COUNTS, mr[self.i + 1:self.j])
+        valid_values = cast(TYPE_COUNTS, mr[self.i + 1 : self.j])
 
         if self._moving_range_uses == AVERAGE:
             value = self._mean(valid_values)
@@ -390,9 +396,9 @@ class Base:
         return any(x > self.limit_floor for x in lnpl)
 
     def rule_1_x_indices_beyond_limits(
-            self,
-            upper_limit: Optional[Decimal] = None,
-            lower_limit: Optional[Decimal] = None,
+        self,
+        upper_limit: Optional[Decimal] = None,
+        lower_limit: Optional[Decimal] = None,
     ) -> List[bool]:
         """
         Points Outside the Limits
@@ -431,7 +437,9 @@ class Base:
         :return: list[bool] A list of boolean values of length(self.moving_ranges())
             True at index i means that self.moving_ranges()[i] is above the Upper Range Limit
         """
-        return self._points_beyond_limits(self.moving_ranges(), self.upper_range_limit())
+        return self._points_beyond_limits(
+            self.moving_ranges(), self.upper_range_limit()
+        )
 
     def rule_2_runs_about_central_line(self) -> List[bool]:
         """
@@ -495,7 +503,7 @@ class Base:
                 near_limits[i] = 1
 
             if i >= 3:
-                successive_values = near_limits[i - 3:i + 1]
+                successive_values = near_limits[i - 3 : i + 1]
                 if abs(sum(successive_values)) >= 3:
                     for j in range(i - 3, i + 1):
                         result[j] = True
@@ -504,9 +512,9 @@ class Base:
 
     @staticmethod
     def _points_beyond_limits(
-            data: TYPE_MOVING_RANGES,
-            upper_limits: Sequence[Decimal],
-            lower_limits: Optional[Sequence[Decimal]] = None
+        data: TYPE_MOVING_RANGES,
+        upper_limits: Sequence[Decimal],
+        lower_limits: Optional[Sequence[Decimal]] = None,
     ) -> List[bool]:
         result = [False] * len(data)
 

--- a/statprocon/charts/xmr/limits/trending.py
+++ b/statprocon/charts/xmr/limits/trending.py
@@ -60,7 +60,9 @@ class Trending(XmR):
         result = [x + delta for x in self.x_central_line()]
         return result
 
-    def lower_natural_process_limit(self, floor: Union[Decimal, int, float] = Decimal('-Infinity')) -> Sequence[Decimal]:
+    def lower_natural_process_limit(
+        self, floor: Union[Decimal, int, float] = Decimal('-Infinity')
+    ) -> Sequence[Decimal]:
         lnpl0 = self.xmr.lower_natural_process_limit()
         x_cl0 = self.xmr.x_central_line()
         delta = x_cl0[0] - lnpl0[0]
@@ -72,19 +74,19 @@ class Trending(XmR):
         Returns the trend or slope of the limit and central lines
         """
 
-        n = len(self.xmr.counts[self.i:self.j]) // 2
+        n = len(self.xmr.counts[self.i : self.j]) // 2
         nd = Decimal(str(n))
 
-        half_average2 = sum(self.xmr.counts[(self.j-n):self.j]) / nd
+        half_average2 = sum(self.xmr.counts[(self.j - n) : self.j]) / nd
         half_average1 = self._half_average1()
 
         result = (half_average2 - half_average1) / nd
         return result
 
     def _half_n(self) -> int:
-        return len(self.xmr.counts[self.i:self.j]) // 2
+        return len(self.xmr.counts[self.i : self.j]) // 2
 
     def _half_average1(self) -> Decimal:
         n = self._half_n()
-        result = sum(self.xmr.counts[self.i:self.i+n]) / Decimal(str(n))
+        result = sum(self.xmr.counts[self.i : self.i + n]) / Decimal(str(n))
         return result

--- a/tests/test_trending.py
+++ b/tests/test_trending.py
@@ -11,10 +11,12 @@ class TrendingTestCase(unittest.TestCase):
         # This data comes from pg. 179 of Making Sense of Data
         #     12.3 Charts for Each Region - Region D
 
+        # fmt: off
         counts = [
             539, 558, 591, 556, 540, 590, 606, 643, 657, 602,
             596, 640, 691, 723, 701, 802, 749, 762, 807, 781,
         ]
+        # fmt: on
 
         c = XmR(counts)
         xmr = XmRTrending(c)
@@ -32,10 +34,12 @@ class TrendingTestCase(unittest.TestCase):
         self.assertIsInstance(xmr.to_csv(), str)
 
     def test_trending_limits_odd_halves(self):
+        # fmt: off
         counts = [
             2.27, 2.55, 2.88, 2.27, 2.93, 3.08, 3.01,
             3.12, 3.31, 3.05, 3.54, 3.45, 3.16, 3.58,
         ]
+        # fmt: on
 
         c = XmR(counts)
         xmr = XmRTrending(c)
@@ -49,10 +53,12 @@ class TrendingTestCase(unittest.TestCase):
 
     def test_negative_trending_limits(self):
         # Region B
+        # fmt: off
         counts = [
             1412, 1280, 1129, 1181, 1149, 1248, 1103, 1021, 1085, 1125,
             910, 999, 883, 851, 997, 878, 939, 834, 688, 806,
         ]
+        # fmt: on
 
         c = XmR(counts)
         xmr = XmRTrending(c)
@@ -64,10 +70,12 @@ class TrendingTestCase(unittest.TestCase):
 
     def test_trending_limits_subset(self):
         # Region C
+        # fmt: off
         counts = [
             1056, 1048, 1129, 1073, 1157, 1146, 1064, 1213, 1088, 1322,
             1256, 1132, 1352, 1353, 1466, 1196, 1330, 1003, 1197, 1337,
         ]
+        # fmt: on
 
         c = XmR(counts, x_central_line_uses='median', subset_end_index=16)
         xmr = XmRTrending(c)
@@ -83,12 +91,14 @@ class TrendingTestCase(unittest.TestCase):
 
     def test_trending_limits_with_subsets(self):
         # Region D
+        # fmt: off
         counts = [
             0, 1,
             539, 558, 591, 556, 540, 590, 606, 643, 657, 602,
             596, 640, 691, 723, 701, 802, 749, 762, 807, 781,
             1000, 2000,
         ]
+        # fmt: on
 
         xmr_normal = XmR(counts[2:-2])
         trend_normal = XmRTrending(xmr_normal)
@@ -96,15 +106,18 @@ class TrendingTestCase(unittest.TestCase):
         xmr_subsets = XmR(counts, subset_start_index=2, subset_end_index=22)
         trend_subsets = XmRTrending(xmr_subsets)
 
-        self.assertEqual(trend_normal.x_central_line(), trend_subsets.x_central_line()[2:-2])
-
+        self.assertEqual(
+            trend_normal.x_central_line(), trend_subsets.x_central_line()[2:-2]
+        )
 
     def test_trending_limits_subset_start_and_end(self):
+        # fmt: off
         counts = [
             5218781, 5385423, 5251728, 5364266, 5466729, 5631477, 5678999, 5757659, 5877636,
             5917390, 6026344, 6137704, 6417100, 6561540, 6719511, 7018027, 7136908, 7318859,
             7538297, 7656486, 7761125, 7785418, 7607722, 7985326, 8497524, 6582273,
         ]
+        # fmt: on
 
         c_subset = XmR(counts[2:15])
         self.assertEqual(Decimal('5908314.077'), c_subset.x_central_line()[0])
@@ -116,7 +129,9 @@ class TrendingTestCase(unittest.TestCase):
 
         self.assertEqual(xmr_subset.slope(), xmr.slope())
 
-        self.assertEqual(Decimal('5203703.347222222222222222223'), xmr.x_central_line()[2])
+        self.assertEqual(
+            Decimal('5203703.347222222222222222223'), xmr.x_central_line()[2]
+        )
         self.assertEqual(xmr_subset.x_central_line(), xmr.x_central_line()[2:15])
 
         half_average_1 = sum(counts[2:8]) / 6  # 5525143

--- a/tests/test_xmr.py
+++ b/tests/test_xmr.py
@@ -64,8 +64,12 @@ mr_cl    : [1.000, 1.000, 1.000]
         xmr = XmR(counts)
 
         result = xmr.to_dict(include_exponential_moving_average=True)
-        result_rounded = list(map(lambda x: round(x, 1), result['x_exponential_moving_average']))
-        expected = xmr.to_decimal_list([139.1, 139.7, 140.0, 140.4, 140.4, 141.1, 141.6, 141.7, 141.8, 142.1])
+        result_rounded = list(
+            map(lambda x: round(x, 1), result['x_exponential_moving_average'])
+        )
+        expected = xmr.to_decimal_list(
+            [139.1, 139.7, 140.0, 140.4, 140.4, 141.1, 141.6, 141.7, 141.8, 142.1]
+        )
         self.assertListEqual(result_rounded, expected)
 
     def test_x_exponential_moving_average_smoothing_factor(self):
@@ -110,18 +114,24 @@ mr_cl    : [1.000, 1.000, 1.000]
         counts = [5.4, 3.8, 8.75, 3.6, 3, 6, 7.4, 10, 5.8, 6.6, 3, 8.8]
         xmr = XmR(counts)
         mr = xmr.moving_ranges()
-        expected = xmr.to_decimal_list([None, 1.6, 4.95, 5.15, 0.6, 3, 1.4, 2.6, 4.2, 0.8, 3.6, 5.8])
+        expected = xmr.to_decimal_list(
+            [None, 1.6, 4.95, 5.15, 0.6, 3, 1.4, 2.6, 4.2, 0.8, 3.6, 5.8]
+        )
         self.assertListEqual(mr, expected)
 
     def test_upper_range_limit(self):
-        counts = [1,51, 100, 50]
+        counts = [1, 51, 100, 50]
         xmr = XmR(counts)
-        self._assert_func_output_equals_line(xmr, 'upper_range_limit', Decimal('162.312'))
+        self._assert_func_output_equals_line(
+            xmr, 'upper_range_limit', Decimal('162.312')
+        )
 
     def test_upper_natural_process_limit(self):
         counts = [1, 10, 100, 50]
         xmr = XmR(counts)
-        self._assert_func_output_equals_line(xmr, 'upper_natural_process_limit', Decimal('172.364'))
+        self._assert_func_output_equals_line(
+            xmr, 'upper_natural_process_limit', Decimal('172.364')
+        )
 
     def test_limits_with_subsets(self):
         counts = [1] * 25
@@ -130,10 +140,14 @@ mr_cl    : [1.000, 1.000, 1.000]
         counts[3] = 50
 
         xmr = XmR(counts, subset_start_index=4, subset_end_index=24)
-        self._assert_func_output_equals_line(xmr, 'upper_natural_process_limit', Decimal('1.000'))
+        self._assert_func_output_equals_line(
+            xmr, 'upper_natural_process_limit', Decimal('1.000')
+        )
         self._assert_func_output_equals_line(xmr, 'upper_range_limit', Decimal('0'))
         self._assert_func_output_equals_line(xmr, 'x_central_line', 1)
-        self.assertEqual(xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit())
+        self.assertEqual(
+            xmr.lower_natural_process_limit(), xmr.upper_natural_process_limit()
+        )
 
     def test_rule_1_points_beyond_upper_limits(self):
         """
@@ -149,7 +163,9 @@ mr_cl    : [1.000, 1.000, 1.000]
         expected = [False] * len(group_a)
         for i in [0, 1]:
             expected[i] = True
-        self.assertListEqual(xmr.rule_1_x_indices_beyond_limits(group_b_upper, group_b_lower), expected)
+        self.assertListEqual(
+            xmr.rule_1_x_indices_beyond_limits(group_b_upper, group_b_lower), expected
+        )
 
     def test_rule_1_points_beyond_lower_limits(self):
         """
@@ -164,17 +180,21 @@ mr_cl    : [1.000, 1.000, 1.000]
         expected = [False] * len(group_b)
         for i in [7, 8, 10, 11]:
             expected[i] = True
-        self.assertListEqual(xmr.rule_1_x_indices_beyond_limits(group_a_upper, group_a_lower), expected)
+        self.assertListEqual(
+            xmr.rule_1_x_indices_beyond_limits(group_a_upper, group_a_lower), expected
+        )
 
     def test_rule_1_points_beyond_both_limits(self):
         """
         This test dataset comes from Table 9.2: Accounts Receivable for Years One and Two in Making Sense of Data
         """
 
+        # fmt: off
         ar_pct_sales = [
             '55.6', '54.7', '54.9', '54.8', '56.9', '55.7', '53.8', '54.8', '53.4', '57.0', '59.4', '63.2',
             '60.9', '60.7', '58.6', '57.3', '56.9', '58.1', '58.3', '50.9', '53.3', '52.5', '50.8', '52.9',
         ]
+        # fmt: on
         xmr = XmR(ar_pct_sales)
 
         upper_limit = Decimal('60.7')
@@ -186,16 +206,20 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertListEqual(actual, expected)
 
         # Point 13 is detected in the chart in the book because the actual percentage is slightly lower than the limit
-        self.assertFalse(actual[13], 'Point 13 equals the limit and should not be detected')
+        self.assertFalse(
+            actual[13], 'Point 13 equals the limit and should not be detected'
+        )
 
     def test_rule_1_point_beyond_upper_range_limit(self):
         """
         This test dataset also comes from Table 9.2
         """
+        # fmt: off
         ar_pct_sales = [
             '55.6', '54.7', '54.9', '54.8', '56.9', '55.7', '53.8', '54.8', '53.4', '57.0', '59.4', '63.2',
             '60.9', '60.7', '58.6', '57.3', '56.9', '58.1', '58.3', '50.9', '53.3', '52.5', '50.8', '52.9',
         ]
+        # fmt: on
         xmr = XmR(ar_pct_sales)
 
         expected = [False] * len(ar_pct_sales)
@@ -206,14 +230,16 @@ mr_cl    : [1.000, 1.000, 1.000]
         """
         This test dataset comes from Table 8.1: Percentage of High School Seniors Who Smooke Daily in Making Sense of Data
         """
-        percentages = [21.3, 20.2, 20.9, 21.0, 18.8, 19.6, 18.7, 18.6, 18.1, 18.9, 19.2, 18.2, 17.3, 19.0]
+        percentages = [21.3, 20.2, 20.9, 21.0, 18.8, 19.6, 18.7, 18.6, 18.1, 18.9, 19.2, 18.2, 17.3, 19.0]  # fmt: skip
 
         xmr = XmR(percentages)
 
+        # fmt: off
         expected = [
             False, False, False, False, False, False,
             True, True, True, True, True, True, True, True
         ]
+        # fmt: on
         self.assertListEqual(xmr.rule_2_runs_about_central_line(), expected)
 
     def test_rule_3(self):
@@ -223,7 +249,7 @@ mr_cl    : [1.000, 1.000, 1.000]
         @see test_peak_flow_rates
         """
 
-        x_values = [120, 140, 100, 150, 260, 150, 100, 120, 300, 300, 275, 300, 140, 1750, 150, 150, 190, 180]
+        x_values = [120, 140, 100, 150, 260, 150, 100, 120, 300, 300, 275, 300, 140, 1750, 150, 150, 190, 180]  # fmt: skip
 
         xmr = XmR(x_values)
 
@@ -238,8 +264,8 @@ mr_cl    : [1.000, 1.000, 1.000]
             Data Set to Use When Verifying Software
         """
 
-        counts = [5045, 4350, 4350, 3975, 4290, 4430, 4485, 4285, 3980, 3925, 3645, 3760, 3300, 3685, 3463, 5200]
-        moving_ranges = [None, 695, 0, 375, 315, 140, 55, 200, 305, 55, 280, 115, 460, 385, 222, 1737]
+        counts = [5045, 4350, 4350, 3975, 4290, 4430, 4485, 4285, 3980, 3925, 3645, 3760, 3300, 3685, 3463, 5200]  # fmt: skip
+        moving_ranges = [None, 695, 0, 375, 315, 140, 55, 200, 305, 55, 280, 115, 460, 385, 222, 1737]  # fmt: skip
         x_avg = Decimal('4135.50')
         mr_avg = Decimal('355.93')
         lnpl = Decimal('3188.72')
@@ -261,8 +287,8 @@ mr_cl    : [1.000, 1.000, 1.000]
         Figure 9.9 XmR Chart for AM Premedication Peak Flow Rates for Days 1 to 18
         """
 
-        x_values = [120, 140, 100, 150, 260, 150, 100, 120, 300, 300, 275, 300, 140, 170, 150, 150, 190, 180]
-        mr_values = [None, 20, 40, 50, 110, 110, 50, 20, 180, 0, 25, 25, 160, 30, 20, 0, 40, 10]
+        x_values = [120, 140, 100, 150, 260, 150, 100, 120, 300, 300, 275, 300, 140, 170, 150, 150, 190, 180]  # fmt: skip
+        mr_values = [None, 20, 40, 50, 110, 110, 50, 20, 180, 0, 25, 25, 160, 30, 20, 0, 40, 10]  # fmt: skip
         x_cl = Decimal('183.1')
         mr_cl = Decimal('52.4')
 
@@ -303,12 +329,14 @@ mr_cl    : [1.000, 1.000, 1.000]
     def test_median_x_central_line(self):
         # Data comes from pg. 147 of Making Sense of Data
         # s10.2 Episode Treatment Groups
+        # fmt: off
         x_values = [
             260, 130, 189, 1080, 175, 200, 193, 120, 33,
             293, 195, 571, 55698, 209, 1825, 239, 290, 254,
             93, 278, 185, 123, 9434, 408, 570, 118, 238,
             207, 153, 209, 243, 110, 306, 343, 244,
         ]
+        # fmt: on
         x_cl = 238
         mr_cl = 125
         unpl = 631.125  # 630 in book
@@ -323,7 +351,9 @@ mr_cl    : [1.000, 1.000, 1.000]
         self.assertEqual(unpl, xmr.upper_natural_process_limit()[0])
         self.assertEqual(url, xmr.upper_range_limit()[0])
 
-    def _assert_func_output_equals_line(self, xmr: XmR, func: str, value: TYPE_COUNT_VALUE):
+    def _assert_func_output_equals_line(
+        self, xmr: XmR, func: str, value: TYPE_COUNT_VALUE
+    ):
         actual = getattr(xmr, func)()
         self._assert_line_equals(actual, value)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1072,6 +1072,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1096,6 +1121,7 @@ plot = [
 dev = [
     { name = "mypy" },
     { name = "mypy-extensions" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1109,6 +1135,7 @@ provides-extras = ["plot"]
 dev = [
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "mypy-extensions", specifier = ">=1.0.0" },
+    { name = "ruff", specifier = ">=0.15.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Final PR of the #12 split. Adopts ruff as the formatter — but deliberately avoids the two things that made #12's diff huge and hard to read: the single→double quote churn, and the explosion of the numeric test fixtures.

## Configuration (`pyproject.toml`)
```toml
[tool.ruff]
line-length = 88
target-version = "py310"   # mirrors requires-python, not .python-version

[tool.ruff.format]
quote-style = "preserve"   # leave existing quotes untouched
```
- **`quote-style = "preserve"`** — no quote churn; existing single quotes stay.
- **`target-version = "py310"`** — matches the support floor (`requires-python`), so if `ruff check`/pyupgrade is added later it won't rewrite to syntax that breaks the 3.10–3.12 we still ship. (`.python-version` 3.13 is just the dev interpreter — a different concept.)
- `ruff>=0.15.0` added to the dev group.

## What actually changed in the code
All idiomatic, quote-free formatting:
- Continuation/signature reindent (12→8 spaces)
- Operator spacing (`n-1` → `n - 1`) and PEP 8 slice spacing (`x[a:b]` → `x[a : b]` for complex slices)
- Wrapping over-long calls/signatures with trailing commas

## Test fixtures protected (the key bit)
ruff only does all-on-one-line or one-per-line, which would have exploded the book-derived numeric data tables. To keep them readable:
- Multi-line grids → wrapped in `# fmt: off` / `# fmt: on`
- Long single-line data lists → `# fmt: skip`

This dropped the test diff from ~423 lines (full explosion) to ~87 (markers + a few legitimate call wraps).

## CI
New `format` job runs `uv run ruff format --check`; the `build` job now depends on `[test, typecheck, format]`.

## Verification
```
uv run ruff format --check          # 13 files already formatted
uv run python -m unittest discover  # 40 tests, OK (skipped=6 without extras)
uv run mypy statprocon tests        # Success: no issues found in 13 source files
```

Net diff: ~173 insertions / 66 deletions (vs #12's 1626 / 269), with zero quote changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)