### PR TITLE
Add tag-triggered PyPI release workflow (trusted publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"          # e.g. v2.0.1
+
+jobs:
+  release:
+    name: Build, publish, and release
+    runs-on: ubuntu-latest
+    environment: pypi          # protected environment; requires approval to publish
+    permissions:
+      id-token: write          # PyPI trusted publishing (OIDC)
+      contents: write          # create the GitHub Release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Verify tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(uv version --short)"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag v$tag does not match pyproject version $version"
+            exit 1
+          fi
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v v="$version" '
+            $0 ~ "^## " v "( |$)" {f=1; next}
+            f && /^## / {exit}
+            f {print}
+          ' CHANGELOG.md > release-notes.md
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            dist/* \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md

--- a/README.md
+++ b/README.md
@@ -206,17 +206,30 @@ Create the virtual environment and install all dependencies (including dev tools
 uv sync
 ```
 
-[Build](https://docs.astral.sh/uv/concepts/projects/build/)
+To [build](https://docs.astral.sh/uv/concepts/projects/build/) the distribution locally:
 
 ```shell
 uv build
 ```
 
-[Upload](https://docs.astral.sh/uv/guides/package/#publishing-your-package)
+### Releasing
 
-```shell
-uv publish
-```
+Releases are published to PyPI automatically by the
+[release workflow](.github/workflows/release.yml) when a version tag is pushed:
+
+1. Bump `version` in `pyproject.toml` and add a matching section to `CHANGELOG.md`.
+2. Merge to `main`.
+3. Tag the release and push the tag:
+
+   ```shell
+   git tag v2.0.1
+   git push origin v2.0.1
+   ```
+
+The workflow verifies the tag matches the package version, builds the
+distribution, publishes to PyPI via [trusted publishing](https://docs.pypi.org/trusted-publishers/)
+(no API tokens), and creates a GitHub Release from the CHANGELOG entry.
+Publishing waits for manual approval on the protected `pypi` environment.
 
 ### Testing
 


### PR DESCRIPTION
Adds automated PyPI releases via GitHub Actions, using **trusted publishing (OIDC)** — no API tokens stored or rotated. Follow-up to the CI work; independent of the other open PRs.

## What it does
`.github/workflows/release.yml` runs when a `v*` tag is pushed:
1. **Approval gate** — runs in a protected `pypi` environment, so it pauses for manual approval before anything publishes.
2. **Tag/version guard** — fails fast if the tag (`v2.0.1`) doesn't match `uv version --short`.
3. **Build** — `uv build` (single pure-Python wheel + sdist).
4. **Publish** — `uv publish --trusted-publishing always` (OIDC; tokenless).
5. **GitHub Release** — `gh release create` with notes auto-extracted from the matching `CHANGELOG.md` section and the dist artifacts attached.

## One-time setup required (browser, not in this PR)
- **PyPI → project → Publishing → Add trusted publisher:** owner `mattmccormick`, repo `statprocon`, workflow `release.yml`, environment `pypi`.
- **GitHub → Settings → Environments → `pypi`:** add a required reviewer to arm the approval gate.

Until the PyPI trusted publisher is configured, the publish step will fail by design (no fallback to tokens) — so merging this PR is safe; it only acts on tag pushes.

## Release flow after setup
```bash
# bump version in pyproject.toml + CHANGELOG, merge to main, then:
git tag v2.0.1 && git push origin v2.0.1
```

## Verified locally
- Tag↔version guard logic (matches `2.0.0`).
- CHANGELOG extraction returns the correct `## 2.0.0` section.
- `release.yml` parses; `uv version --short` and `uv publish --trusted-publishing` confirmed available.

README's Development section updated to document the tag-based release process in place of the manual `uv build` / `uv publish` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)